### PR TITLE
Static config path to dynamic & reload config keybinding

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -143,7 +143,8 @@ vim.keymap.set("n", "<leader>ff", ":find ", { desc = "Find file" })
 vim.keymap.set("n", "J", "mzJ`z", { desc = "Join lines and keep cursor position" })
 
 -- Quick config editing
-vim.keymap.set("n", "<leader>rc", ":e ~/.config/nvim/init.lua<CR>", { desc = "Edit config" })
+vim.keymap.set("n", "<leader>rc", ":e $MYVIMRC<CR>", { desc = "Edit config" })
+vim.keymap.set("n", "<leader>rl", ":so $MYVIMRC<CR>", { desc = "Reload config" })
 
 -- ============================================================================
 -- USEFUL FUNCTIONS


### PR DESCRIPTION
Working with different nvim configs (sometimes just copying the existing config folder to create a new one), I need to update the correct folder path for the "Edit config" keybinding.

Looking at
```
:h $MYVIMRC
```
I think this is the best option to make it dynamic.