### PR TITLE
Fix: deprecated nvim_buf_get_option(), nvim_win_set_option() and termopen()

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -300,11 +300,10 @@ local function FloatingTerminal()
   })
 
   -- Set transparency for the floating window
-  vim.api.nvim_win_set_option(terminal_state.win, 'winblend', 0)
+  vim.api.nvim_set_option_value('winblend', 0, { win = terminal_state.win })
 
   -- Set transparent background for the window
-  vim.api.nvim_win_set_option(terminal_state.win, 'winhighlight',
-    'Normal:FloatingTermNormal,FloatBorder:FloatingTermBorder')
+  vim.api.nvim_set_option_value('winhighlight', 'Normal:FloatingTermNormal,FloatBorder:FloatingTermBorder', { win = terminal_state.win })
 
   -- Define highlight groups for transparency
   vim.api.nvim_set_hl(0, "FloatingTermNormal", { bg = "none" })


### PR DESCRIPTION
API deprecated in 0.10
- [nvim_buf_get_option()](https://neovim.io/doc/user/deprecated.html#nvim_buf_get_option())
- [nvim_win_set_option()](https://neovim.io/doc/user/deprecated.html#nvim_win_set_option())

VIMSCRIPT deprecated in 0.11
[termopen()](https://neovim.io/doc/user/deprecated.html#termopen())

This is my first time tinkering with Lua. Please test thoroughly :)