### PR TITLE
Avoid restoring position for git commits, etc.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -174,7 +174,11 @@ vim.api.nvim_create_autocmd("BufReadPost", {
   callback = function()
     local mark = vim.api.nvim_buf_get_mark(0, '"')
     local lcount = vim.api.nvim_buf_line_count(0)
-    if mark[1] > 0 and mark[1] <= lcount then
+    local line = mark[1]
+    local ft = vim.bo.filetype
+    if line > 0 and line <= lcount
+      and vim.fn.index({ "commit", "gitrebase", "xxd" }, ft) == -1
+      and not vim.o.diff then
       pcall(vim.api.nvim_win_set_cursor, 0, mark)
     end
   end,


### PR DESCRIPTION
Avoid restoring position for git commits, rebases, binary files, and diffs. See https://neovim.io/doc/user/usr_05.html#restore-cursor.