### PR TITLE
Fix diagnostic float config: using true insted of "always"

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -629,7 +629,7 @@ vim.diagnostic.config({
 	severity_sort = true,
 	float = {
 		border = "rounded",
-		source = "always",
+		source = true,
 		header = "",
 		prefix = "",
 		focusable = false,


### PR DESCRIPTION
According to `:h vim.diagnostic.Opts.Float` the value should be
 - `true` (always)
 - 'false`
 - `"if_many"`

