### PR TITLE
Reuse CloseFloatingTerminalFunction instead of new inline definition

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -361,12 +361,7 @@ end
 
 -- Key mappings
 vim.keymap.set("n", "<leader>t", FloatingTerminal, { noremap = true, silent = true, desc = "Toggle floating terminal" })
-vim.keymap.set("t", "<Esc>", function()
-  if terminal_state.is_open then
-    vim.api.nvim_win_close(terminal_state.win, false)
-    terminal_state.is_open = false
-  end
-end, { noremap = true, silent = true, desc = "Close floating terminal from terminal mode" })
+vim.keymap.set("t", "<Esc>", CloseFloatingTerminal, { noremap = true, silent = true, desc = "Close floating terminal from terminal mode" })
 
 
 -- ============================================================================


### PR DESCRIPTION
Thanks for the beautiful init.lua ❤️ . I've just found small inconsistency and decided to do a quick pr.

Use previously defined  function instead of new inline definition